### PR TITLE
switch to bash script

### DIFF
--- a/.github/workflows/buiild.yml
+++ b/.github/workflows/buiild.yml
@@ -5,22 +5,18 @@ on:
   pull_request:
 
 jobs:
-  build-push-image:
+  build-push-images:
     # pull requests are a duplicate of a branch push if within the same repo.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: true
-      # run the matrix in sequence - using the buildx cache for speed
-      max-parallel: 1
-      matrix:
-        target: ["developer", "runtime"]
-        architecture: ["rtems", "linux"]
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Log in to GitHub Docker Registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
@@ -28,10 +24,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -41,31 +33,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - name: Docker meta
-        id: meta-dev
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}-${{ matrix.architecture }}-developer
-          tags: |
-            type=ref,event=branch
-            type=ref,event=tag
-
-      - name: Build image
-        uses: docker/build-push-action@v2
-        with:
-          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
-          target: ${{ matrix.target }}
-          build-args: TARGET_ARCHITECTURE=${{ matrix.architecture }}
-          tags: ${{ steps.meta-dev.outputs.tags }}
-          labels: ${{ steps.meta-dev.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      # Stop the cache growing indefinitely (remove when the below is fixed)
-      # When removing this change cache-to above
-      # https://github.com/docker/build-push-action/issues/252#issuecomment-744400434
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: Docker Build Script
+        env:
+          ARCHITECTURES: rtems linux
+          REPOSITORY: ${{ github.repository }}
+          CACHE: /tmp/.buildx-cache
+          PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags') }}
+          TAG: ${{ github.ref_name }}
+        run: .github/workflows/build.sh

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# A script for building EPICS container images
+#
+# Note that this is done in bash to make it portable between
+# CI frameworks. This approach uses the minimum of GitHub Actions
+# features. It is also intended to work locally for testing outside
+# of CI.
+#
+
+# Notes on podman vs docker buildx
+# see https://pythonspeed.com/articles/podman-buildkit/
+# podman does not support the same caching buildx at present
+
+# PREREQUISITES: the caller should be authenticated to the
+# container registry for push (when PUSH is true)
+
+# work with docker or podman (for local builds)
+podman=false
+if [ -z $(which docker 2> /dev/null) ] ; then
+    podman=true
+    alias docker=podman
+fi
+
+# Provide some defaults for the controlling Environment Variables.
+# Supported ARCHTECTURES are linux rtems
+ARCHITECTURES=${ARCHITECTURES:-linux}
+REPOSITORY=${REPOSITORY:-localtest}
+CACHE=${CACHE:-/tmp/.docker-cache}
+PUSH=${PUSH:-false}
+TAG=${TAG:-latest}
+
+cachefrom=${CACHE}
+cacheto=/tmp/.buildx-new
+mkdir -p ${cacheto}
+
+for ARCHITECTURE in ${ARCHITECTURES}; do
+    for TARGET in developer runtime; do
+
+        image_name=${REPOSITORY}-${ARCHITECTURE}-${TARGET}
+        args="--build-arg TARGET_ARCHITECTURE=${ARCHITECTURE} --target ${TARGET} -t ${image_name} ."
+
+        if [[ $podman==true ]] ; then
+            podman build ${args}
+        else
+            docker buildx build --cache-to=type=local,dest=${cacheto} \
+              --cache-from=type=local,dest=${cachefrom} ${args}
+        fi
+        # only the first build uses the externally provided cache
+        # that way we can avoid indefinitely growning cache
+        cachefrom=${cacheto}
+
+        if [[ ${PUSH}==true ]] ; then
+            docker push ${image_name}
+        fi
+    done
+done
+
+# overwrite the external cache with our new cache
+# this approach means that the cache does not indefinitely grow
+rm -rf ${CACHE}
+mv ${cacheto} ${CACHE}


### PR DESCRIPTION
Use bash to iterate over the builds instead of GHA.
This makes us more CI agnostic and gives more control over the caching for faster build.