### PR TITLE
Abandon Cache

### DIFF
--- a/.github/workflows/buiild.yml
+++ b/.github/workflows/buiild.yml
@@ -23,14 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CACHE }}
-          key: ${{ runner.os }}-${{ matrix.architecture }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.architecture }}-buildx-
-
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -75,9 +75,6 @@ do_build() {
 # as every layer will get uploaded to the cache even if it just came out of the
 # cache.
 
-do_build ${ARCH} developer ${cachefrom}
-do_build ${ARCH} runtime ${cachefrom} ${cacheto}
+do_build ${ARCH} developer
+do_build ${ARCH} runtime
 
-# remove old cache to avoid indefinite growth
-rm -rf ${CACHE}
-mv ${NEWCACHE} ${CACHE}


### PR DESCRIPTION
Caching the two target architectures is not reliable and when it fails it is considerably slower than turning off all cache.

Will keep cache for IOCs as they may benefit, especially single arch ones.