### PR TITLE
Fixed dev container build after upgrade to Ubuntu Resolute

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
         "args": {
             // Native target development settings ==============================
             "EPICS_TARGET_ARCH": "linux-x86_64",
-            "BASE_IMAGE": "ubuntu:24.04"
+            "BASE_IMAGE": "ghcr.io/diamondlightsource/ubuntu-devcontainer:resolute"
             // Local cross compilation settings ================================
             // "EPICS_TARGET_ARCH": "RTEMS-beatnik",
             // "BASE_IMAGE": "ghcr.io/epics-containers/rtems-beatnik-runtime"

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update -y && \
 # get and build EPICS base
 COPY epics ${EPICS_ROOT}
 RUN git clone https://github.com/epics-base/epics-base \
-    --branch ${EPICS_VERSION} -q  ${EPICS_BASE} && \
+        --branch ${EPICS_VERSION} -q  ${EPICS_BASE} && \
     bash ${EPICS_ROOT}/scripts/patch-epics-base.sh
 RUN make -C ${EPICS_BASE} -j $(nproc); make -C ${EPICS_BASE} clean
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update -y && \
     inotify-tools \
     libevent-dev \
     libreadline-dev \
+    libcrypt-dev \
     re2c \
     rsync \
     && rm -rf /var/lib/apt/lists/*
@@ -45,7 +46,7 @@ COPY epics ${EPICS_ROOT}
 RUN git clone https://github.com/epics-base/epics-base \
         --branch ${EPICS_VERSION} -q  ${EPICS_BASE} && \
     bash ${EPICS_ROOT}/scripts/patch-epics-base.sh
-RUN make -C ${EPICS_BASE} -j $(nproc); make -C ${EPICS_BASE} clean
+RUN make -C ${EPICS_BASE} -j $(nproc); ls -l ${EPICS_BASE}/lib/linux-x86_64/libdbRecStd.a
 
 # build pvxs
 RUN bash ${EPICS_ROOT}/scripts/make_pvxs.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,9 +44,9 @@ RUN apt-get update -y && \
 # get and build EPICS base
 COPY epics ${EPICS_ROOT}
 RUN git clone https://github.com/epics-base/epics-base \
-        --branch ${EPICS_VERSION} -q  ${EPICS_BASE} && \
+    --branch ${EPICS_VERSION} -q  ${EPICS_BASE} && \
     bash ${EPICS_ROOT}/scripts/patch-epics-base.sh
-RUN make -C ${EPICS_BASE} -j $(nproc); ls -l ${EPICS_BASE}/lib/linux-x86_64/libdbRecStd.a
+RUN make -C ${EPICS_BASE} -j $(nproc); make -C ${EPICS_BASE} clean
 
 # build pvxs
 RUN bash ${EPICS_ROOT}/scripts/make_pvxs.sh


### PR DESCRIPTION
The dev container build was failing, so I put in these fixes, which seemed to work:
devcontainer.json was using Ubuntu 24.04 so I changed it to Resolute to be consistent with Dockerfile.
Added libcrypt-dev to apt-get


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Development Environment**
  * Updated the development container base image for a more standardized setup.
  * Added required cryptographic development libraries to the developer environment.
  * No changes to application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->