### PR TITLE
Changed devcontainer's BASE_IMAGE to DLS's Ubuntu image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
         "args": {
             // Native target development settings ==============================
             "EPICS_TARGET_ARCH": "linux-x86_64",
-            "BASE_IMAGE": "ubuntu:24.04"
+            "BASE_IMAGE": "ghcr.io/diamondlightsource/ubuntu-devcontainer:noble"
             // Local cross compilation settings ================================
             // "EPICS_TARGET_ARCH": "RTEMS-beatnik",
             // "BASE_IMAGE": "ghcr.io/epics-containers/rtems-beatnik-runtime"


### PR DESCRIPTION
Changed devcontainer's BASE_IMAGE to ghcr.io/diamondlightsource/ubuntu-devcontainer:noble

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development container’s underlying image to provide a more standardized development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->